### PR TITLE
Typo in variable name

### DIFF
--- a/logs_api.py
+++ b/logs_api.py
@@ -172,7 +172,7 @@ def save_data(api_request, part):
     
     if len(splitted_text_filtered) > 1:
         output_data = '\n'.join(splitted_text_filtered[1:]) #.encode('utf-8')
-        output_date = '\t'.join(map(clickhouse.get_ch_field_name, splitted_text_filtered[0].split('\t'))) + '\n' + output_data # convert headers to CH column names
+        output_data = '\t'.join(map(clickhouse.get_ch_field_name, splitted_text_filtered[0].split('\t'))) + '\n' + output_data # convert headers to CH column names
         output_data = output_data.replace(r"\'", "'") # to correct escapes in params
 
         clickhouse.save_data(api_request.user_request.source,


### PR DESCRIPTION
In the result of typo TSV loaded without header names.